### PR TITLE
Change set typeof check to allow functions

### DIFF
--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -1,4 +1,3 @@
-import { typeOf } from 'ember-runtime/utils';
 import { assert } from 'ember-metal/debug';
 import { GUID_KEY } from 'ember-metal/utils';
 import { meta } from 'ember-metal/meta';
@@ -6,8 +5,22 @@ import { meta } from 'ember-metal/meta';
 var id = 0;
 function UNDEFINED() {}
 
+function isPrimitiveType(thing) {
+  switch(typeof thing) {
+    case 'string':
+    case 'boolean':
+    case 'number':
+    case 'undefined':
+    case 'null':
+    case 'symbol':
+      return true;
+    default:
+      return false;
+  }
+}
+
 /*
- * @private
+ * @public
  * @class Ember.WeakMap
  *
  * Weak relationship from Map -> Key, but not Key to Map.
@@ -41,7 +54,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', typeOf(obj) === 'object');
+  assert('Uncaught TypeError: Invalid value used as weak map key', !isPrimitiveType(obj));
 
   if (value === undefined) {
     value = UNDEFINED;
@@ -59,11 +72,7 @@ WeakMap.prototype.set = function(obj, value) {
 WeakMap.prototype.has = function(obj) {
   var map = meta(obj).readableWeak();
 
-  if (map && map[this._id] !== undefined) {
-    return true;
-  }
-
-  return false;
+  return (map && map[this._id] !== undefined);
 };
 
 /*

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -5,20 +5,6 @@ import { meta } from 'ember-metal/meta';
 var id = 0;
 function UNDEFINED() {}
 
-function isPrimitiveType(thing) {
-  switch(typeof thing) {
-    case 'string':
-    case 'boolean':
-    case 'number':
-    case 'undefined':
-    case 'null':
-    case 'symbol':
-      return true;
-    default:
-      return false;
-  }
-}
-
 /*
  * @public
  * @class Ember.WeakMap
@@ -54,7 +40,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', !isPrimitiveType(obj));
+  assert('Uncaught TypeError: Invalid value used as weak map key', typeof obj === 'object' || typeof obj === 'function');
 
   if (value === undefined) {
     value = UNDEFINED;

--- a/packages/ember-metal/lib/weak_map.js
+++ b/packages/ember-metal/lib/weak_map.js
@@ -40,7 +40,7 @@ WeakMap.prototype.get = function(obj) {
  * @return {Any} stored value
  */
 WeakMap.prototype.set = function(obj, value) {
-  assert('Uncaught TypeError: Invalid value used as weak map key', typeof obj === 'object' || typeof obj === 'function');
+  assert('Uncaught TypeError: Invalid value used as weak map key', obj && (typeof obj === 'object' || typeof obj === 'function'));
 
   if (value === undefined) {
     value = UNDEFINED;

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -59,10 +59,6 @@ QUnit.test('that error is thrown when using a primitive key', function(assert) {
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
   expectAssertion(function() {
-    map.set(Symbol(), 1);
-  }, /Uncaught TypeError: Invalid value used as weak map key/);
-
-  expectAssertion(function() {
     map.set(true, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -47,30 +47,30 @@ QUnit.test('has weakMap like qualities', function(assert) {
   equal(map.get(b), undefined);
 });
 
-QUnit.test('that error is thrown when using a non object key', function(assert) {
+QUnit.test('that error is thrown when using a primitive key', function(assert) {
   var map = new WeakMap();
 
-  throws(function() {
+  expectAssertion(function() {
     map.set('a', 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(1, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(Symbol(), 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(true, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(null, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 
-  throws(function() {
+  expectAssertion(function() {
     map.set(undefined, 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
 });

--- a/packages/ember-metal/tests/weak_map_test.js
+++ b/packages/ember-metal/tests/weak_map_test.js
@@ -53,6 +53,26 @@ QUnit.test('that error is thrown when using a non object key', function(assert) 
   throws(function() {
     map.set('a', 1);
   }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(1, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(Symbol(), 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(true, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(null, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
+
+  throws(function() {
+    map.set(undefined, 1);
+  }, /Uncaught TypeError: Invalid value used as weak map key/);
 });
 
 QUnit.test('that .has and .delete work as expected', function(assert) {
@@ -72,4 +92,3 @@ QUnit.test('that .has and .delete work as expected', function(assert) {
   map.set(a, undefined);
   ok(map.has(a));
 });
-


### PR DESCRIPTION
Native WeakMaps allow:

```js
var wm = new WeakMap();
wm.set(function() {}, 'whyyyyyyy');
```

so updating the logic to support this